### PR TITLE
Fix README formatting for psutil install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ This is the "hub" part of a solar powered APRS RF-Weather station project for am
 
 ```bash
 cp hubTelemetry.conf.template hubTelemetry.conf
+```
 
-- psutil
 Install psutil:
 
 ```bash
 pip3 install psutil
-
+```


### PR DESCRIPTION
## Summary
- clean up README code blocks
- ensure the psutil install instructions render as a separate block

## Testing
- `python3 -m py_compile hubTelemetry.py`


------
https://chatgpt.com/codex/tasks/task_e_683f9087fdb08323bd2c7a363d56e2e6