### PR TITLE
Escape KISS reserved bytes in frame

### DIFF
--- a/hubTelemetry.py
+++ b/hubTelemetry.py
@@ -107,7 +107,16 @@ def build_aprs_info(lat, lon, symbol_table, symbol, version, cpu_temp, cpu_load,
 
 # Send KISS frame to Direwolf
 def send_via_kiss(ax25_frame):
-    kiss_frame = b'\xC0\x00' + ax25_frame + b'\xC0'
+    escaped = bytearray()
+    for b in ax25_frame:
+        if b == 0xC0:
+            escaped += b"\xDB\xDC"
+        elif b == 0xDB:
+            escaped += b"\xDB\xDD"
+        else:
+            escaped.append(b)
+
+    kiss_frame = b"\xC0\x00" + bytes(escaped) + b"\xC0"
     with socket.create_connection(("127.0.0.1", 8001)) as s:
         s.send(kiss_frame)
 

--- a/tests/test_kiss.py
+++ b/tests/test_kiss.py
@@ -1,0 +1,43 @@
+import unittest
+from unittest.mock import patch
+import hubTelemetry
+
+class DummySocket:
+    def __init__(self):
+        self.sent = b''
+    def send(self, data):
+        self.sent += data
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+class TestKissEscaping(unittest.TestCase):
+    def _run_send(self, payload):
+        dummy = DummySocket()
+        with patch('socket.create_connection', return_value=dummy):
+            hubTelemetry.send_via_kiss(payload)
+        return dummy.sent
+
+    def test_no_escape(self):
+        data = b'\x01\x02\x03'
+        expected = b'\xC0\x00\x01\x02\x03\xC0'
+        self.assertEqual(self._run_send(data), expected)
+
+    def test_escape_c0(self):
+        data = b'\xC0'
+        expected = b'\xC0\x00\xDB\xDC\xC0'
+        self.assertEqual(self._run_send(data), expected)
+
+    def test_escape_db(self):
+        data = b'\xDB'
+        expected = b'\xC0\x00\xDB\xDD\xC0'
+        self.assertEqual(self._run_send(data), expected)
+
+    def test_escape_mixed(self):
+        data = b'\xC0\xDB'
+        expected = b'\xC0\x00\xDB\xDC\xDB\xDD\xC0'
+        self.assertEqual(self._run_send(data), expected)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- escape FEND and FESC bytes before framing KISS packets
- add unit tests verifying KISS escaping logic

## Testing
- `python3 -m unittest discover -v tests`

------
https://chatgpt.com/codex/tasks/task_e_683f92c3163c8323b254724bd7c89467