### PR TITLE
Add wx-heliox-direwolf submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "external/direwolf"]
-	path = external/direwolf
-	url = https://github.com/kf0tke/wx-helios-direwolf
+path = external/direwolf
+url = https://github.com/kf0tke/wx-heliox-direwolf


### PR DESCRIPTION
## Summary
- remove old direwolf submodule
- add `.gitmodules` for `wx-heliox-direwolf`
- add gitlink entry for new submodule

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hubTelemetry')*

------
https://chatgpt.com/codex/tasks/task_e_683fab9699b48323b68e1489ae6758b9