### PR TITLE
Add build_direwolf.sh helper

### DIFF
--- a/build_direwolf.sh
+++ b/build_direwolf.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Build and install the wx-helios-direwolf submodule
+
+set -e
+
+# Initialize submodule if needed
+if [ ! -d "external/direwolf" ] || [ ! -d "external/direwolf/.git" ]; then
+    git submodule update --init external/direwolf
+fi
+
+cd external/direwolf
+mkdir -p build
+cd build
+cmake ..
+make -j$(nproc)
+sudo make install
+


### PR DESCRIPTION
## Summary
- add a helper script for building the bundled `wx-helios-direwolf` submodule

## Testing
- `PYTHONPATH=. pytest -q`
- `./build_direwolf.sh` *(fails: could not find ALSA/hamlib)*

------
https://chatgpt.com/codex/tasks/task_e_6840d992af1c8323a6b8fdeb86a7164a