### PR TITLE
Add run script for wx-helios-direwolf

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ make -j4
 sudo make install
 ```
 
+## Running wx-helios-direwolf
+
+Start the Direwolf TNC with the helper script:
+
+```bash
+./run_direwolf.sh
+```
+
+This uses `direwolf.conf` (copied from the template if missing) and writes
+logs to `direwolf.log`.
+
 
 ## Configuration
 

--- a/run_direwolf.sh
+++ b/run_direwolf.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Launch the Direwolf TNC using the wx-helios-direwolf build
+
+set -e
+
+CONF="direwolf.conf"
+
+# If the local configuration doesn't exist, create it from the template
+if [ ! -f "$CONF" ]; then
+    cp direwolf.conf.template "$CONF"
+fi
+
+# Run Direwolf with the configuration and log to direwolf.log
+exec direwolf -c "$CONF" -l direwolf.log


### PR DESCRIPTION
## Summary
- add `run_direwolf.sh` helper for the wx‑helios‑direwolf TNC
- document how to run Direwolf with the new script

## Testing
- `pip install psutil`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684118c2b2008323ac321a5067d7baf8