### PR TITLE
Ignore pytest cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # Python cache files
 __pycache__/
 *.pyc
+.pytest_cache/
 
 # Running conf file from template
 hubTelemetry.conf


### PR DESCRIPTION
## Summary
- extend `.gitignore` to exclude `.pytest_cache/`

## Testing
- `pip install psutil`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684121b284648323a3cb25152ee9edd0