### PR TITLE
Add build script mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ make -j4
 sudo make install
 ```
 
+Or run the helper script from the repository root to perform the above steps automatically:
+
+```bash
+./build_direwolf.sh
+```
+
 ## Running wx-helios-direwolf
 
 Start the Direwolf TNC with the helper script:


### PR DESCRIPTION
## Summary
- document that `./build_direwolf.sh` can automate building the wx-helios-direwolf submodule

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841223e37848323b8b7fa9257ab1dd2