### PR TITLE
Add rigctld helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,21 @@ Start the Direwolf TNC with the helper script:
 This uses `direwolf.conf` (copied from the template if missing) and writes
 logs to `direwolf.log`.
 
+## Running rigctld
+
+Launch `rigctld` for radio control with the helper script. Pass the rig model ID
+and the `/dev/ttyUSB` device number:
+
+```bash
+./run_rigctld.sh <rig-id> <usb-num>
+```
+
+For example to start model `503` on `/dev/ttyUSB0`:
+
+```bash
+./run_rigctld.sh 503 0
+```
+
 
 ## Configuration
 

--- a/run_rigctld.sh
+++ b/run_rigctld.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Start rigctld with the specified rig model and serial adapter
+
+set -e
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <rig-id> <ttyUSB number>" >&2
+    echo "Example: $0 503 0" >&2
+    exit 1
+fi
+
+RIG_ID="$1"
+USB_NUM="$2"
+
+exec rigctld -m "$RIG_ID" -r "/dev/ttyUSB${USB_NUM}" -t 4531


### PR DESCRIPTION
## Summary
- add `run_rigctld.sh` to launch rigctld with a given model and port
- document new script in README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68413ff4f8148323bd7e44d6e7cd8e89