### PR TITLE
Add wxnow handling to run_direwolf

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ Start the Direwolf TNC with the helper script:
 ./run_direwolf.sh
 ```
 
-This uses `direwolf.conf` (copied from the template if missing) and writes
-logs to `direwolf.log`.
+This uses `direwolf.conf` (copied from the template if missing), ensures the
+`runtime/` directory exists and passes `runtime/wxnow.txt` to Direwolf using the
+`-w` option. Logs are written to `direwolf.log`.
 
 ## Running rigctld
 

--- a/run_direwolf.sh
+++ b/run_direwolf.sh
@@ -4,11 +4,16 @@
 set -e
 
 CONF="direwolf.conf"
+RUNTIME_DIR="runtime"
+WXNOW="$RUNTIME_DIR/wxnow.txt"
 
 # If the local configuration doesn't exist, create it from the template
 if [ ! -f "$CONF" ]; then
     cp direwolf.conf.template "$CONF"
 fi
 
-# Run Direwolf with the configuration and log to direwolf.log
-exec direwolf -c "$CONF" -l direwolf.log
+# Ensure runtime directory exists for wxnow file
+mkdir -p "$RUNTIME_DIR"
+
+# Run Direwolf with the configuration, wxnow file and log to direwolf.log
+exec direwolf -c "$CONF" -l direwolf.log -w "$WXNOW"


### PR DESCRIPTION
## Summary
- ensure `runtime/` exists when launching Direwolf
- pass `runtime/wxnow.txt` to Direwolf via `-w`
- document new behavior in README

## Testing
- `pip install -r requirements.txt`
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b3aa5ce608323be24f704a89c0564