### PR TITLE
Run direwolf from local build

### DIFF
--- a/build_direwolf.sh
+++ b/build_direwolf.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Build and install the wx-helios-direwolf submodule
+# Build the wx-helios-direwolf submodule without installing
 
 set -e
 
@@ -13,5 +13,4 @@ mkdir -p build
 cd build
 cmake ..
 make -j$(nproc)
-sudo make install
 

--- a/run_direwolf.sh
+++ b/run_direwolf.sh
@@ -16,4 +16,4 @@ fi
 mkdir -p "$RUNTIME_DIR"
 
 # Run Direwolf with the configuration, wxnow file and log to direwolf.log
-exec direwolf -c "$CONF" -l direwolf.log -w "$WXNOW"
+exec "$(dirname "$0")/external/direwolf/build/src/direwolf" -c "$CONF" -l direwolf.log -w "$WXNOW"


### PR DESCRIPTION
## Summary
- avoid installing direwolf in `build_direwolf.sh`
- invoke the direwolf binary directly from the `external/direwolf` build directory in `run_direwolf.sh`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hubTelemetry')*

------
https://chatgpt.com/codex/tasks/task_e_685b3d9731188323b98e4e82596382cd